### PR TITLE
Fix Node.js warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: dotnet nuget push **/ci/*.nupkg --source "GPR" --skip-duplicate --api-key ${{ secrets.GITHUB_TOKEN }}
 
       - name: Delete old packages
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v5
         with:
           min-versions-to-keep: 5
           package-type: 'nuget'


### PR DESCRIPTION
Minor change to fix this warning:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/delete-package-versions@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```