### PR TITLE
Fix existing package check during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,9 @@ jobs:
                     grep -oP '(?<=\.)[0-9]+\.[0-9]+\.[0-9]+((-[a-zA-Z]+)?(\.[0-9]+)*)*$' \
                 )
                 # get package id by truncating the version from the file name
-                _packageId="${_filenamewithoutext%%.$_version}"
+                _packageId="${_filenamewithoutext%%.$_packageVersion}"
                 # verify all packages have the same version
-                if [ $_releaseVersion != "" ] && [ $_packageVersion != $_releaseVersion ] ; then
+                if [[ $_releaseVersion != "" ]] && [[ $_packageVersion != $_releaseVersion ]]; then
                     # mulitple package versions detected
                     echo "Multiple package versions detected. Expected '${_releaseVersion}' but found '${_packageVersion}' for '${_packageId}'."; exit 1
                 else
@@ -82,9 +82,9 @@ jobs:
                 _packageUrl="https://api.nuget.org/v3/registration5-semver1/${_packageIdLower}/${_packageVersion}.json"
                 echo "Checking for existing package at ${_packageUrl}"
                 _statusCode=$(curl -s -o /dev/null -I -w '%{http_code}' "${_packageUrl}")
-                if [ $_statusCode == "200" ]; then
+                if [[ $_statusCode == "200" ]]; then
                     echo "The package ${_packageId} with version ${_packageVersion} already exists on nuget.org"; exit 1
-                elif [ $_statusCode == "404" ]; then
+                elif [[ $_statusCode == "404" ]]; then
                     echo "Confirmed package ${_packageId} with version ${_packageVersion} does not already exist on nuget.org"
                 else
                     echo "Unexpected status code ${_statusCode} received from nuget.org"; exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           name: nupkg
       
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
 
       - name: Add nuget.org source
         run: dotnet nuget add source --name NUGET https://www.nuget.org


### PR DESCRIPTION
Fixes existing package checks and adds double-brackets for improved bash string comparison.

The `_version` variable doesn't actually exist in the script.

This will always return 404: https://api.nuget.org/v3/registration5-semver1/aspirant.hosting.0.0.4/0.0.4.json

This is the correct link: https://api.nuget.org/v3/registration5-semver1/aspirant.hosting/0.0.4.json

The double-brackets should fix the error on `line 19`.

![image](https://github.com/aspirant-project/aspirant/assets/29800/3b528f1d-338c-40fd-a9d9-03c367294fa9)

This also fixes the `Node.js` warning:
![image](https://github.com/aspirant-project/aspirant/assets/29800/f10e379a-9884-48b0-8507-54ef385edd64)

